### PR TITLE
Check NaNs using `isNaN()` method built in to Javascript

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -578,7 +578,7 @@ export function getTypeOf(value: unknown): string {
   // Handle primitive types (string, number, boolean, undefined, symbol, bigint)
   const type = typeof value;
   if (type !== "object" && type !== "function") {
-    // handle NaN (all NaNs are numbers)
+    // Handle NaN (all NaNs are numbers)
     if (type === "number" && isNaN(value)) {
       return "nan";
     }

--- a/mod.ts
+++ b/mod.ts
@@ -570,11 +570,6 @@ export function getTypeOf(value: unknown): string {
     return "null";
   }
 
-  // Handle NaN (Note: NaN is the only value in JavaScript which is not equal to itself)
-  if (value !== value) {
-    return "nan";
-  }
-
   // Handle Infinity (both positive and negative)
   if (value === Infinity || value === -Infinity) {
     return "infinity";
@@ -583,6 +578,10 @@ export function getTypeOf(value: unknown): string {
   // Handle primitive types (string, number, boolean, undefined, symbol, bigint)
   const type = typeof value;
   if (type !== "object" && type !== "function") {
+    // handle NaN (all NaNs are numbers)
+    if (type === "number" && isNaN(value)) {
+      return "nan";
+    }
     return type.toLowerCase();
   }
 


### PR DESCRIPTION
This PR checks for `NaN` types using the [`isNaN()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN) function instead of using `value !== value`.

According to Javascript, all `NaNs` are numbers, i.e. `typeof NaN === "number"`, hence we need to check if the type is a number first, and then check for `NaN`.

Directly running `isNaN()` on any value has some consequences as highlighted by MDN:

> This behavior of isNaN() for non-numeric arguments can be confusing! For example, an empty string is coerced to 0, while a boolean is coerced to 0 or 1; both values are intuitively "not numbers", but they don't evaluate to NaN, so isNaN() returns false. Therefore, isNaN() answers neither the question "is the input the floating point [NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) value" nor the question "is the input not a number".
>
> – *<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN>*